### PR TITLE
fix: timeout not awaited

### DIFF
--- a/src/fb_signer.ts
+++ b/src/fb_signer.ts
@@ -31,7 +31,7 @@ export class FbSigner {
             if(tx.status != prevStatus){
                 console.log("Transaction's status: " + tx.status);
             }
-            setTimeout(() => { }, 4000); 
+            await new Promise((resolve) => setTimeout(resolve, 4000));
         }
         
         return (await this.fireblocks.getTransactionById(fbTx.id));


### PR DESCRIPTION
The delay on checking the transction's status was inop, and needed to be awaited.

Proposed change now actually waits 4 seconds before querying the status again